### PR TITLE
chore: Group and cool down Dependabot updates, pin actions to SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,30 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 2
+    groups:
+      # Actions are numerous and generate noisy PRs, so bundle them into one.
+      # All actions are SHA-pinned, so minor/patch updates are meaningful too.
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 2
+    groups:
+      # Bundle minor/patch into one PR to cut review overhead (major stays separate).
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
+      # @types/node is pinned to the Node runtime major (see package.json engines).
+      # No need for v25+ types until the runtime itself is upgraded.
       - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: 'package.json'
           cache: pnpm
@@ -26,7 +26,7 @@ jobs:
       issues: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       # This repo intentionally contains expired sample TODOs (README/fixtures),
       # so the action correctly calls setFailed. That is expected for this smoke test.
       - uses: ./


### PR DESCRIPTION
## Summary
- `dependabot.yml`: bundle github-actions / npm minor-patch updates into groups and add a 2-day cooldown to cut PR noise
- Pin `actions/checkout` and `actions/setup-node` to commit SHA in `test.yml` so Dependabot can track their minor/patch updates too (previously only major-version tags were tracked)

## Test plan
- [x] Validated YAML syntax of `dependabot.yml` and `test.yml`
- [x] Verified pinned SHAs resolve to the intended tags via the GitHub API